### PR TITLE
Added four new popular PECL extensions: LZF, oauth, stomp, and yaml.

### DIFF
--- a/binary-builds/php-extensions.yml
+++ b/binary-builds/php-extensions.yml
@@ -66,6 +66,10 @@ extensions:
   version: 3.0.5
   md5: 844bd1528161518a47415f709214bae9
   klass: PeclRecipe
+- name: LZF
+  version: 1.6.6
+  md5: 571af186b274f56114e659b42956b6ce
+  klass: PeclRecipe
 - name: mailparse
   version: 2.1.6
   md5: 0f84e1da1d074a4915a9bcfe2319ce84
@@ -86,6 +90,10 @@ extensions:
   version: 0.5.7
   md5: b87b5c5e0dab9f41c824201abfbf363d
   klass: PeclRecipe
+- name: oauth
+  version: 1.2.3
+  md5: 99838d9a04b78058c7360dfd69c8593b
+  klass: PeclRecipe
 - name: protocolbuffers
   version: 0.2.6
   md5: a304ca632b0d7c5710d5590ac06248a9
@@ -98,6 +106,10 @@ extensions:
   version: 2.4.0
   md5: 2c9accf66681a3daaaf371bc07e44902
   klass: PeclRecipe
+- name: stomp
+  version: 1.0.9
+  md5: c173185be1fbc09bf0aab534fb01f456
+  klass: PeclRecipe
 - name: sundown
   version: 0.3.11
   md5: c1397e9d3312226ec6c84e8e34c717a6
@@ -109,6 +121,10 @@ extensions:
 - name: yaf
   version: 2.3.5
   md5: 77d5d9d6c8471737395350966986bc2e
+  klass: PeclRecipe
+- name: yaml
+  version: 1.3.1
+  md5: f07a87ae08f79fdca448fad3f1d359f4
   klass: PeclRecipe
 
   #non-standard

--- a/binary-builds/php7-extensions.yml
+++ b/binary-builds/php7-extensions.yml
@@ -58,6 +58,10 @@ extensions:
   version: 3.4.3
   md5: d0ee25c007cd2a28cefccc0b9ee63a28
   klass: PeclRecipe
+- name: LZF
+  version: 1.6.6
+  md5: 571af186b274f56114e659b42956b6ce
+  klass: PeclRecipe
 - name: mailparse
   version: 3.0.2
   md5: 4bd96a980013374f23a7461cc0a919aa
@@ -69,6 +73,10 @@ extensions:
 - name: msgpack
   version: 2.0.2
   md5: 02f7e109d438072c4b642b01cf78533e
+  klass: PeclRecipe
+- name: oauth
+  version: 2.0.2
+  md5: 2f133a53b0949544ed5cfe9b668ce55a
   klass: PeclRecipe
 - name: pdo_odbc
   version: nil
@@ -90,6 +98,10 @@ extensions:
   version: 2.4.0
   md5: 2c9accf66681a3daaaf371bc07e44902
   klass: PeclRecipe
+- name: stomp
+  version: 2.0.1
+  md5: 960d763ace9f2102178ece937d4e6812
+  klass: PeclRecipe
 - name: xdebug
   version: 2.6.0
   md5: ed3545852e6f4a00fb8730362d0431ee
@@ -97,6 +109,10 @@ extensions:
 - name: yaf
   version: 3.0.6
   md5: 1c6da90820cc0dc37f4dfdd381b59bf1
+  klass: PeclRecipe
+- name: yaml
+  version: 2.0.2
+  md5: 63183e8cc921219bd901d4acf57f3187
   klass: PeclRecipe
 - name: memcached
   version: 3.0.3

--- a/binary-builds/php72-extensions.yml
+++ b/binary-builds/php72-extensions.yml
@@ -58,6 +58,10 @@ extensions:
   version: 3.4.3
   md5: d0ee25c007cd2a28cefccc0b9ee63a28
   klass: PeclRecipe
+- name: LZF
+  version: 1.6.6
+  md5: 571af186b274f56114e659b42956b6ce
+  klass: PeclRecipe
 - name: mailparse
   version: 3.0.2
   md5: 4bd96a980013374f23a7461cc0a919aa
@@ -69,6 +73,10 @@ extensions:
 - name: msgpack
   version: 2.0.2
   md5: 02f7e109d438072c4b642b01cf78533e
+  klass: PeclRecipe
+- name: oauth
+  version: 2.0.2
+  md5: 2f133a53b0949544ed5cfe9b668ce55a
   klass: PeclRecipe
 - name: pdo_odbc
   version: nil
@@ -86,6 +94,10 @@ extensions:
   version: 3.1.6
   md5: 500775d653988a17f3e44f6d5f605b32
   klass: PeclRecipe
+- name: stomp
+  version: 2.0.1
+  md5: 960d763ace9f2102178ece937d4e6812
+  klass: PeclRecipe
 - name: xdebug
   version: 2.6.0
   md5: ed3545852e6f4a00fb8730362d0431ee
@@ -93,6 +105,10 @@ extensions:
 - name: yaf
   version: 3.0.6
   md5: 1c6da90820cc0dc37f4dfdd381b59bf1
+  klass: PeclRecipe
+- name: yaml
+  version: 2.0.2
+  md5: 63183e8cc921219bd901d4acf57f3187
   klass: PeclRecipe
 - name: memcached
   version: 3.0.3


### PR DESCRIPTION
Adding support for these popular (based on download stats) PECL extensions:
 - LZF
 - oauth
 - stomp
 - yaml