### PR TITLE
Build the readline extension.

### DIFF
--- a/binary-builds/php7-extensions.yml
+++ b/binary-builds/php7-extensions.yml
@@ -90,6 +90,10 @@ extensions:
   version: 3.0.5
   md5: 844bd1528161518a47415f709214bae9
   klass: PeclRecipe
+- name: readline
+  version: nil
+  md5: nil
+  klass: ReadlineRecipe
 - name: redis
   version: 3.1.6
   md5: 500775d653988a17f3e44f6d5f605b32

--- a/binary-builds/php72-extensions.yml
+++ b/binary-builds/php72-extensions.yml
@@ -90,6 +90,10 @@ extensions:
   version: 3.0.5
   md5: 844bd1528161518a47415f709214bae9
   klass: PeclRecipe
+- name: readline
+  version: nil
+  md5: nil
+  klass: ReadlineRecipe
 - name: redis
   version: 3.1.6
   md5: 500775d653988a17f3e44f6d5f605b32


### PR DESCRIPTION
[This change](https://github.com/cloudfoundry/binary-builder/pull/35) enabled building readline as an extension, but this PR is needed so that the build system actually builds and include the extension.