### PR TITLE
Build the tideways and tideways_xhprof extensions.

### DIFF
--- a/binary-builds/php7-extensions.yml
+++ b/binary-builds/php7-extensions.yml
@@ -144,6 +144,14 @@ extensions:
   version: 0.12.2
   md5: 85f6985f08fd41783c0c05b4049c7da1
   klass: PHPProtobufPeclRecipe
+- name: tideways
+  version: 4.1.5
+  md5: 2d0e5d14c975a1a357afe64ce171a185
+  klass: TidewaysXhprofRecipe
+- name: tideways_xhprof
+  version: 5.0-beta2
+  md5: 2d0e5d14c975a1a357afe64ce171a185
+  klass: TidewaysXhprofRecipe
 
 #Oracle client stuff. Not included unless libs are present
 - name: oci8

--- a/binary-builds/php72-extensions.yml
+++ b/binary-builds/php72-extensions.yml
@@ -140,6 +140,14 @@ extensions:
   version: 0.12.2
   md5: 85f6985f08fd41783c0c05b4049c7da1
   klass: PHPProtobufPeclRecipe
+- name: tideways
+  version: 4.1.5
+  md5: 2d0e5d14c975a1a357afe64ce171a185
+  klass: TidewaysXhprofRecipe
+- name: tideways_xhprof
+  version: 5.0-beta2
+  md5: 2d0e5d14c975a1a357afe64ce171a185
+  klass: TidewaysXhprofRecipe
 
 #Oracle client stuff. Not included unless libs are present
 - name: oci8


### PR DESCRIPTION
This pairs with https://github.com/cloudfoundry/binary-builder/pull/36

It will build two versions of the tideways extension.  The 4.x branch is older and has the extension name of `tideways`, but with the 5.x branch the extension name changes to `tideways_xhprof`.  There are also some minor updates that are required to use the 5.x branch.  As such, and because the 5.x branch is still beta, I'm adding both.  At some point in the future, the 4.x branch can be retired but it seems necessary for now.